### PR TITLE
Fix module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alvaroloes/enumer
+module github.com/benavento/enumer
 
 go 1.12
 


### PR DESCRIPTION
In order to download and use this fork, the module name should match the repo name